### PR TITLE
Edited Notebook for Carla 0.9.10

### DIFF
--- a/carla-simulator.ipynb
+++ b/carla-simulator.ipynb
@@ -1,10 +1,23 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "carla-simulator.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "accelerator": "GPU"
+  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "gpY-9ehVv70N",
-        "colab_type": "text"
+        "id": "gpY-9ehVv70N"
       },
       "source": [
         "# Running CARLA simulator\n",
@@ -29,8 +42,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "_HATkoTPmgg5",
-        "colab_type": "text"
+        "id": "_HATkoTPmgg5"
       },
       "source": [
         "<img src=\"https://raw.githubusercontent.com/MichaelBosello/carla-colab/master/img/screen.png\" width=\"750\">"
@@ -39,8 +51,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Tsln_9Oc4rUR",
-        "colab_type": "text"
+        "id": "Tsln_9Oc4rUR"
       },
       "source": [
         "---\n",
@@ -66,8 +77,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "5jsE5t9G6nY4",
-        "colab_type": "text"
+        "id": "5jsE5t9G6nY4"
       },
       "source": [
         "## Requirements\n",
@@ -83,8 +93,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "__kiSsQE-R7v",
-        "colab_type": "text"
+        "id": "__kiSsQE-R7v"
       },
       "source": [
         "## Change the runtime\n",
@@ -94,8 +103,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "-YdPX4a3_XFg",
-        "colab_type": "text"
+        "id": "-YdPX4a3_XFg"
       },
       "source": [
         "## Installation & setup of remote access \n",
@@ -118,23 +126,20 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "w4Ywwr43AGR9",
-        "colab_type": "code",
-        "colab": {}
+        "id": "w4Ywwr43AGR9"
       },
       "source": [
         "!pip install git+https://github.com/demotomohiro/remocolab.git\n",
         "import remocolab\n",
         "remocolab.setupVNC()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "zbMpTEeFG_lO",
-        "colab_type": "text"
+        "id": "zbMpTEeFG_lO"
       },
       "source": [
         "## Connect TurboVNC\n",
@@ -153,8 +158,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "d3OWsY6jNQqJ",
-        "colab_type": "text"
+        "id": "d3OWsY6jNQqJ"
       },
       "source": [
         "## Download CARLA\n",
@@ -166,21 +170,18 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "rI7R3brAJgyQ",
-        "colab_type": "code",
-        "colab": {}
+        "id": "rI7R3brAJgyQ"
       },
       "source": [
-        "! sudo -u colab wget -O /home/colab/CARLA.tar.gz https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/CARLA_0.9.8.tar.gz"
+        "! sudo -u colab wget -O /home/colab/CARLA.tar.gz https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/CARLA_0.9.5.tar.gz"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "AozeZpibPB6u",
-        "colab_type": "text"
+        "id": "AozeZpibPB6u"
       },
       "source": [
         "## Extract the zip"
@@ -189,22 +190,39 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "rfRiKysEL3eR",
-        "colab_type": "code",
-        "colab": {}
+        "id": "rfRiKysEL3eR"
       },
       "source": [
         "! sudo -u colab mkdir /home/colab/carla\n",
         "! sudo -u colab tar -xf /home/colab/CARLA.tar.gz -C /home/colab/carla"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "m7kFVqEfT59y",
-        "colab_type": "text"
+        "id": "UNqp1sGJb_Yy"
+      },
+      "source": [
+        "# Install PyPI carla"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "LOb0GketcSWX"
+      },
+      "source": [
+        "! sudo -u colab pip3 install carla"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "m7kFVqEfT59y"
       },
       "source": [
         "## Run CARLA"
@@ -213,21 +231,18 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "wok54OiA7E91",
-        "colab_type": "code",
-        "colab": {}
+        "id": "wok54OiA7E91"
       },
       "source": [
-        "! sudo -u colab DISPLAY=:1 vglrun /home/colab/carla/CarlaUE4.sh"
+        "! sudo -u colab DISPLAY=:1 vglrun /home/colab/carla/CarlaUE4.sh -carla-server"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "qmpPO81jUEh1",
-        "colab_type": "text"
+        "id": "qmpPO81jUEh1"
       },
       "source": [
         "---\n",
@@ -243,7 +258,7 @@
         "\n",
         "### Install requirement\n",
         "\n",
-        "1. `sudo pip install pygame`\n",
+        "1. `sudo pip3 install pygame`\n",
         "\n",
         "  * The password for colab user is shown above\n",
         "\n",
@@ -251,7 +266,7 @@
         "\n",
         "2. `cd /home/colab/carla/PythonAPI/examples`\n",
         "\n",
-        "3. `python manual_control.py`\n",
+        "3. `python3 manual_control.py`\n",
         "\n",
         "\n",
         "## Display smooth animation\n",
@@ -262,7 +277,13 @@
         "\n",
         "### Keeping the virtual machine alive\n",
         "https://stackoverflow.com/questions/57113226/how-to-prevent-google-colab-from-disconnecting\n",
-        "\n",
+        "```\n",
+        "function ConnectButton(){\n",
+        "    console.log(\"Connect pushed\"); \n",
+        "    document.querySelector(\"#top-toolbar > colab-connect-button\").shadowRoot.querySelector(\"#connect\").click() \n",
+        "}\n",
+        "setInterval(ConnectButton,60000);\n",
+        "```\n",
         "### How to transfer code\n",
         "Options:\n",
         "* Develop on your pc and use git to trasfer the code\n",
@@ -278,22 +299,19 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "qz4MypzAvltW",
-        "colab_type": "code",
-        "colab": {}
+        "id": "qz4MypzAvltW"
       },
       "source": [
         "from google.colab import drive\n",
         "drive.mount('/content/drive')"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "9EoV3sC1vr37",
-        "colab_type": "text"
+        "id": "9EoV3sC1vr37"
       },
       "source": [
         "\n",
@@ -340,19 +358,5 @@
         "Close CARLA always from the remote desktop, if you interrupt the execution from the colab web-page you will interrupt also the VNC server."
       ]
     }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "carla-simulator.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "GPU"
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/carla-simulator.ipynb
+++ b/carla-simulator.ipynb
@@ -27,14 +27,19 @@
         "\n",
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/MichaelBosello/carla-colab/blob/master/carla-simulator.ipynb\">\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/Computer-CGuy/carla-colab/blob/master/carla-simulator.ipynb\">\n",
         "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />\n",
         "    Run in Google Colab</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/MichaelBosello/carla-colab\">\n",
+        "    <a target=\"_blank\" href=\"https://github.com/Computer-CGuy/carla-colab\">\n",
         "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
         "    View source on GitHub</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/MichaelBosello/carla-colab\">\n",
+        "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
+        "    Forked From</a>\n",
         "  </td>\n",
         "</table>"
       ]
@@ -173,7 +178,7 @@
         "id": "rI7R3brAJgyQ"
       },
       "source": [
-        "! sudo -u colab wget -O /home/colab/CARLA.tar.gz https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/CARLA_0.9.5.tar.gz"
+        "! sudo -u colab wget -O /home/colab/CARLA.tar.gz https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/CARLA_0.9.10.1.tar.gz"
       ],
       "execution_count": null,
       "outputs": []
@@ -195,26 +200,6 @@
       "source": [
         "! sudo -u colab mkdir /home/colab/carla\n",
         "! sudo -u colab tar -xf /home/colab/CARLA.tar.gz -C /home/colab/carla"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "UNqp1sGJb_Yy"
-      },
-      "source": [
-        "# Install PyPI carla"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "LOb0GketcSWX"
-      },
-      "source": [
-        "! sudo -u colab pip3 install carla"
       ],
       "execution_count": null,
       "outputs": []
@@ -256,17 +241,22 @@
         "\n",
         "From a terminal on the remote desktop\n",
         "\n",
+        "### For Python3\n",
+        "\n",
+        "1. Install python3.7 first\n",
+        "  `sudo apt install python3.7`\n",
+        "\n",
         "### Install requirement\n",
         "\n",
-        "1. `sudo pip3 install pygame`\n",
+        "2. `sudo python3.7 -m pip install pygame`\n",
         "\n",
         "  * The password for colab user is shown above\n",
         "\n",
         "### Run the 'manual control' example\n",
         "\n",
-        "2. `cd /home/colab/carla/PythonAPI/examples`\n",
+        "3. `cd /home/colab/carla/PythonAPI/examples`\n",
         "\n",
-        "3. `python3 manual_control.py`\n",
+        "4. `python3.7 manual_control.py`\n",
         "\n",
         "\n",
         "## Display smooth animation\n",
@@ -277,7 +267,7 @@
         "\n",
         "### Keeping the virtual machine alive\n",
         "https://stackoverflow.com/questions/57113226/how-to-prevent-google-colab-from-disconnecting\n",
-        "```\n",
+        "```js\n",
         "function ConnectButton(){\n",
         "    console.log(\"Connect pushed\"); \n",
         "    document.querySelector(\"#top-toolbar > colab-connect-button\").shadowRoot.querySelector(\"#connect\").click() \n",


### PR DESCRIPTION
Carla 0.9.5 is the latest version available on https://pypi.org/
Python3 can work with Carla Simulator instead of Python2.
Snippets are added in the Notebook for ease of access.