### PR TITLE
Updated link to Carla version 0.9.10 

### DIFF
--- a/carla-simulator.ipynb
+++ b/carla-simulator.ipynb
@@ -174,7 +174,7 @@
         "id": "rI7R3brAJgyQ"
       },
       "source": [
-        "! sudo -u colab wget -O /home/colab/CARLA.tar.gz https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/CARLA_0.9.8.tar.gz"
+        "! sudo -u colab wget -O /home/colab/CARLA.tar.gz https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/CARLA_0.9.10.tar.gz"
       ],
       "execution_count": null,
       "outputs": []
@@ -196,6 +196,37 @@
       "source": [
         "! sudo -u colab mkdir /home/colab/carla\n",
         "! sudo -u colab tar -xf /home/colab/CARLA.tar.gz -C /home/colab/carla"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BFrH9p95pjg2"
+      },
+      "source": [
+        "## Setup PythonAPI\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "25tiIe4WsXpt"
+      },
+      "source": [
+        "! sudo -u colab rm -rf /home/colab/carla/PythonAPI/carla/dist/*.egg"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FA5rNhxpp0zw"
+      },
+      "source": [
+        "! sudo -u colab wget https://github.com/Computer-CGuy/carla-colab/raw/master/carla-0.9.10-py3.6-linux-x86_64.egg -P /home/colab/carla/PythonAPI/carla/dist/"
       ],
       "execution_count": null,
       "outputs": []
@@ -244,7 +275,7 @@
         "\n",
         "### Install requirement\n",
         "\n",
-        "1. `sudo pip install pygame`\n",
+        "1. `sudo pip3 install pygame`\n",
         "\n",
         "  * The password for colab user is shown above\n",
         "\n",
@@ -252,7 +283,7 @@
         "\n",
         "2. `cd /home/colab/carla/PythonAPI/examples`\n",
         "\n",
-        "3. `python manual_control.py`\n",
+        "3. `python3 manual_control.py`\n",
         "\n",
         "---\n",
         "\n",


### PR DESCRIPTION
Latest Carla release contains Carla/PythonAPI builds for python 3.7 only. Latest Colab version supports python 3.6.9 and python 2.7 . 
`carla-0.9.10-py3.6-linux-x86_64.egg ` is included to support colab python version.